### PR TITLE
Update guzzlehttp/guzzle version to 6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ The composer packages introduced by this plugin are listed below:
 - **predis/predis** at version `~1.0`
 - **league/flysystem-rackspace** at version `~1.0`
 - **league/flysystem-aws-s3-v3** at version `~1.0`
-- **guzzlehttp/guzzle** at version `~6.0`
+- **guzzlehttp/guzzle** at version `~6.3`

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "league/flysystem-rackspace": "~1.0",
         "league/flysystem-aws-s3-v3": "~1.0",
 
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "~6.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This fixes an error under PHP 7.2: 
when sending Mails via Mailgun, the following Error was thrown:

```
ErrorException: count(): Parameter must be an array or an object that implements Countable in (...)/drivers/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php:67
```
The mail was sent anyway - but there are of course problems when an Exception ist thrown, for example in queues the job will be called again if you have set the queue to multiple retries, and in the backend an error popup appears when sending a mail.