### PR TITLE
Update guzzle for aws error fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "league/flysystem-rackspace": "~1.0",
         "league/flysystem-aws-s3-v3": "~1.0",
 
-        "guzzlehttp/guzzle": "~6.2.1"
+        "guzzlehttp/guzzle": "~6.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "league/flysystem-rackspace": "~1.0",
         "league/flysystem-aws-s3-v3": "~1.0",
 
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "~6.2.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Not sure if I should use 6.2 or 6.3 version but it's what I use and that's what's specified in aws as a minimum version.