### PR TITLE
Add laravelcollective/remote (SSH)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 composer.phar
 .DS_Store
 .idea
+.ftpconfig

--- a/Plugin.php
+++ b/Plugin.php
@@ -2,6 +2,7 @@
 
 use System\Classes\PluginBase;
 
+use Illuminate\Foundation\AliasLoader;
 /**
  * Drivers Plugin Information File
  */
@@ -21,5 +22,15 @@ class Plugin extends PluginBase
             'icon'        => 'icon-leaf',
             'homepage'    => 'https://github.com/octoberrain/drivers-plugin'
         ];
+    }
+
+    public function boot()
+    {
+        // Register ServiceProviders
+        \App::register('Collective\Remote\RemoteServiceProvider');
+
+        // Register aliases
+        $alias = \Illuminate\Foundation\AliasLoader::getInstance();
+        $alias->alias('SSH', 'Collective\Remote\RemoteFacade');
     }
 }

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ The composer packages introduced by this plugin are listed below:
 - **league/flysystem-rackspace** at version `~1.0`
 - **league/flysystem-aws-s3-v3** at version `~1.0`
 - **guzzlehttp/guzzle** at version `~6.0`
+- **laravelcollective/remote** at version `5.4.*`

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,9 @@
         "league/flysystem-rackspace": "~1.0",
         "league/flysystem-aws-s3-v3": "~1.0",
 
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "~6.0",
+
+        "laravelcollective/remote": "5.4.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I have added "laravelcollective/remote" since I consider it very useful, I hope so and consider integrating it, to avoid making an extra plugin just for this feature.

Doc:
https://laravelcollective.com/docs/5.4/ssh